### PR TITLE
Update front-envoy.yaml

### DIFF
--- a/front-proxy/front-envoy.yaml
+++ b/front-proxy/front-envoy.yaml
@@ -28,7 +28,8 @@ static_resources:
                   cluster: service2
           http_filters:
           - name: envoy.filters.http.router
-            typed_config: {}
+            typed_config: 
+             "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   - address:
       socket_address:
@@ -58,7 +59,8 @@ static_resources:
                   cluster: service2
           http_filters:
           - name: envoy.filters.http.router
-            typed_config: {}
+            typed_config: 
+             "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
       transport_socket:
         name: envoy.transport_sockets.tls


### PR DESCRIPTION
fixed the error: exiting
front-proxy-front-envoy-1  | Didn't find a registered implementation for 'envoy.filters.http.router' with type URL: ''